### PR TITLE
Static Lifetime on id method and i8, i16 support

### DIFF
--- a/public/templates/accountsParserPage.njk
+++ b/public/templates/accountsParserPage.njk
@@ -109,7 +109,7 @@ impl yellowstone_vixen_core::Parser for AccountParser {
     type Input = yellowstone_vixen_core::AccountUpdate;
     type Output = {{ programName | pascalCase }}ProgramState;
 
-    fn id(&self) -> std::borrow::Cow<str> {
+    fn id(&self) -> std::borrow::Cow<'static, str> {
         "{{ programName | snakeCase }}::AccountParser".into()
     }
 

--- a/public/templates/instructionsParserPage.njk
+++ b/public/templates/instructionsParserPage.njk
@@ -38,7 +38,7 @@ impl yellowstone_vixen_core::Parser for InstructionParser {
     #[cfg(feature = "shared-data")]
     type Output = InstructionUpdateOutput<{{ programName  | pascalCase }}ProgramIx>;
     
-    fn id(&self) -> std::borrow::Cow<str> {
+    fn id(&self) -> std::borrow::Cow<'static, str> {
         "{{ programName  | pascalCase }}::InstructionParser".into()
     }
 

--- a/src/getRenderMapVisitor.ts
+++ b/src/getRenderMapVisitor.ts
@@ -134,6 +134,8 @@ function getNumberTypeTransform(type: NumberTypeNode) {
 
         case 'u8':
         case 'u16':
+        case 'i8':
+        case 'i16':
             return `.into()`;
 
         default:


### PR DESCRIPTION
## Changes
- Resolve build error regarding missing `static` lifetime on id method of the parser
- Expand generator support to `i8` and `i16`