### PR TITLE
chore: Update for vixen 0.5.1 and allow discriminator

### DIFF
--- a/public/templates/accountsParserPage.njk
+++ b/public/templates/accountsParserPage.njk
@@ -109,7 +109,7 @@ impl yellowstone_vixen_core::Parser for AccountParser {
     type Input = yellowstone_vixen_core::AccountUpdate;
     type Output = {{ programName | pascalCase }}ProgramState;
 
-    fn id(&self) -> std::borrow::Cow<str> {
+    fn id(&self) -> std::borrow::Cow<'static, str> {
         "{{ programName | snakeCase }}::AccountParser".into()
     }
 

--- a/public/templates/instructionsParserPage.njk
+++ b/public/templates/instructionsParserPage.njk
@@ -38,7 +38,7 @@ impl yellowstone_vixen_core::Parser for InstructionParser {
     #[cfg(feature = "shared-data")]
     type Output = InstructionUpdateOutput<{{ programName  | pascalCase }}ProgramIx>;
     
-    fn id(&self) -> std::borrow::Cow<str> {
+    fn id(&self) -> std::borrow::Cow<'static, str> {
         "{{ programName  | pascalCase }}::InstructionParser".into()
     }
 

--- a/src/getProtoTypeManifestVisitor.ts
+++ b/src/getProtoTypeManifestVisitor.ts
@@ -56,12 +56,14 @@ export function numberTypeToProtoHelper(numberType: NumberTypeNode): string {
 }
 
 export function getProtoTypeManifestVisitor(options: {
+    allowDiscriminator?: boolean;
     getImportFrom: GetImportFromFunction;
     getTraitsFromNode: GetTraitsFromNodeFunction;
     nestedStruct?: boolean;
     parentName?: string | null;
 }) {
     const { getTraitsFromNode } = options;
+    const allowDiscriminator = options.allowDiscriminator ?? false;
     let parentName: string | null = options.parentName ?? null;
     let nestedStruct: boolean = options.nestedStruct ?? false;
     let inlineStruct: boolean = false;
@@ -370,7 +372,7 @@ export function getProtoTypeManifestVisitor(options: {
 
                     const fieldName = snakeCase(structFieldType.name);
 
-                    if (fieldName === 'discriminator') {
+                    if (!allowDiscriminator && fieldName === 'discriminator') {
                         return {
                             imports: new ImportMap(),
                             nestedStructs: [],

--- a/src/getRenderMapVisitor.ts
+++ b/src/getRenderMapVisitor.ts
@@ -39,6 +39,7 @@ import { ImportMap } from './ImportMap';
 import { getBytesFromBytesValueNode, getImportFromFactory, render } from './utils';
 
 export type GetRenderMapOptions = {
+    allowDiscriminatorField?: boolean;
     generateProto?: boolean;
     projectCrateDescription?: string;
     projectFolder: string;
@@ -443,7 +444,11 @@ export function getRenderMapVisitor(options: GetRenderMapOptions) {
     const getTraitsFromNode = (_node: AccountNode | DefinedTypeNode) => {
         return { imports: new ImportMap(), render: '' };
     };
-    const typeManifestVisitor = getProtoTypeManifestVisitor({ getImportFrom, getTraitsFromNode });
+    const typeManifestVisitor = getProtoTypeManifestVisitor({
+        allowDiscriminator: options.allowDiscriminatorField ?? false,
+        getImportFrom,
+        getTraitsFromNode,
+    });
 
     return pipe(
         staticVisitor(() => createRenderMap(), {
@@ -484,7 +489,9 @@ export function getRenderMapVisitor(options: GetRenderMapOptions) {
                         return {
                             discriminator: discriminator ? `[${discriminator.join(', ')}]` : null,
                             fields: accData.fields
-                                .filter(field => field.name !== 'discriminator')
+                                .filter(
+                                    field => options.allowDiscriminatorField === true || field.name !== 'discriminator',
+                                )
                                 .map(field => {
                                     return {
                                         name: snakeCase(field.name),
@@ -517,7 +524,7 @@ export function getRenderMapVisitor(options: GetRenderMapOptions) {
                         ).length;
 
                         const ixArgs = ix.arguments
-                            .filter(arg => arg.name !== 'discriminator')
+                            .filter(arg => options.allowDiscriminatorField === true || arg.name !== 'discriminator')
                             .map(arg => {
                                 return {
                                     name: snakeCase(arg.name),

--- a/test/accountsParserPage.test.ts
+++ b/test/accountsParserPage.test.ts
@@ -50,7 +50,7 @@ test('it renders accounts parsers', () => {
         'impl yellowstone_vixen_core::Parser for AccountParser',
         'async fn parse',
         'fn prefilter(&self) -> yellowstone_vixen_core::Prefilter',
-        'fn id(&self) -> std::borrow::Cow<str>',
+        "fn id(&self) -> std::borrow::Cow<'static, str>",
         'type Input = yellowstone_vixen_core::AccountUpdate',
         'type Output = TestProgramState',
     ]);


### PR DESCRIPTION
- Updated Cow<str> to Cow<'static, str>
- Added option to not skip "discriminator" argument within a struct for cases where users need the discriminator