### PR TITLE
Use latest RenderMap type from renderers-core

### DIFF
--- a/.changeset/great-walls-think.md
+++ b/.changeset/great-walls-think.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-vixen-parser': patch
+---
+
+Use latest RenderMap type from renderers-core

--- a/package.json
+++ b/package.json
@@ -38,11 +38,11 @@
         "test:e2e": "./e2e/test.sh"
     },
     "dependencies": {
-        "@codama/errors": "^1.3.7",
-        "@codama/nodes": "^1.3.7",
-        "@codama/renderers-core": "^1.2.2",
-        "@codama/visitors-core": "^1.3.7",
-        "@codama/renderers-rust": "^1.2.6",
+        "@codama/errors": "^1.4.1",
+        "@codama/nodes": "^1.4.1",
+        "@codama/renderers-core": "^1.3.0",
+        "@codama/visitors-core": "^1.4.1",
+        "@codama/renderers-rust": "^1.2.8",
         "@solana/codecs-strings": "^5.0.0",
         "nunjucks": "^3.2.4"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,19 +9,19 @@ importers:
   .:
     dependencies:
       '@codama/errors':
-        specifier: ^1.3.7
+        specifier: ^1.4.1
         version: 1.4.1
       '@codama/nodes':
-        specifier: ^1.3.7
+        specifier: ^1.4.1
         version: 1.4.1
       '@codama/renderers-core':
-        specifier: ^1.2.2
-        version: 1.2.5
+        specifier: ^1.3.0
+        version: 1.3.0
       '@codama/renderers-rust':
-        specifier: ^1.2.6
-        version: 1.2.7(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+        specifier: ^1.2.8
+        version: 1.2.8(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@codama/visitors-core':
-        specifier: ^1.3.7
+        specifier: ^1.4.1
         version: 1.4.1
       '@solana/codecs-strings':
         specifier: ^5.0.0
@@ -321,11 +321,11 @@ packages:
   '@codama/nodes@1.4.1':
     resolution: {integrity: sha512-gqr87Neh3g0+0nubVC3j4JNT99xC4flv72Z8Yjplz5vxoU+IncE3Rsv3mr8V1AC0k8fv5/ND21OcSOK44Wbh2g==}
 
-  '@codama/renderers-core@1.2.5':
-    resolution: {integrity: sha512-MJ+PjUSalPuperZFeH9t7vNY/HXUv0QfVjVAIvi+Z4ey51hLPyzSLg4IYq96hYvLpTomMp4socpVecKoyOgzrA==}
+  '@codama/renderers-core@1.3.0':
+    resolution: {integrity: sha512-39ugOM7c6AT5h6azC8lix6YGA17u8wSsCzJbDrShTzRgz+QHWVF1Uci/v4CEcesEHgGQigP6f1jGAnEoTb/gcQ==}
 
-  '@codama/renderers-rust@1.2.7':
-    resolution: {integrity: sha512-wD6JRfm4GZmY0vUhgHB1fTHIaCw3zrQ7PXl4Fv1hBNiX6hKor5vE72GkIztG/VCZkl1WWVJTNLRLho5oldN9LQ==}
+  '@codama/renderers-rust@1.2.8':
+    resolution: {integrity: sha512-ZxCIy8XKVK/oFfogawfzv2oC26mhGfSZ9tb8YW855bcj7BwatxNDG+l19MA1/tIEKUFhgz/oZiH2Ky1CWLCmXw==}
     engines: {node: '>=20.18.0'}
 
   '@codama/visitors-core@1.4.1':
@@ -1107,12 +1107,6 @@ packages:
   '@sinonjs/fake-timers@13.0.5':
     resolution: {integrity: sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==}
 
-  '@solana/codecs-core@3.0.3':
-    resolution: {integrity: sha512-emKykJ3h1DmnDOY29Uv9eJXP8E/FHzvlUBJ6te+5EbKdFjj7vdlKYPfDxOI6iGdXTY+YC/ELtbNBh6QwF2uEDQ==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
   '@solana/codecs-core@5.0.0':
     resolution: {integrity: sha512-rCG2d8OaamVF2/J//YyCgDqNJpUytVVltw9C8mJtEz5c6Se/LR6BFuG8g4xeJswq/ab4RFk5/HFdgbvNjKgQjA==}
     engines: {node: '>=20.18.0'}
@@ -1125,23 +1119,10 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/codecs-numbers@3.0.3':
-    resolution: {integrity: sha512-pfXkH9J0glrM8qj6389GAn30+cJOxzXLR2FsPOHCUMXrqLhGjMMZAWhsQkpOQ37SGc/7EiQsT/gmyGC7gxHqJQ==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
   '@solana/codecs-numbers@5.0.0':
     resolution: {integrity: sha512-a2+skRLuUK02f/XFe4L0e1+wHCyfK25PkyseFps1v1l4pvevukFwth/EhSyrs6w5CsTJRVoR7MuE3E00PM4egw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/codecs-strings@3.0.3':
-    resolution: {integrity: sha512-VHBXnnTVtcQ1j+7Vrz+qSYo38no+jiHRdGnhFspRXEHNJbllzwKqgBE7YN3qoIXH+MKxgJUcwO5KHmdzf8Wn2A==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      fastestsmallesttextencoderdecoder: ^1.0.22
       typescript: '>=5.3.3'
 
   '@solana/codecs-strings@5.0.0':
@@ -1154,13 +1135,6 @@ packages:
   '@solana/codecs@5.0.0':
     resolution: {integrity: sha512-KOw0gFUSBxIMDWLJ3AkVFkEci91dw0Rpx3C6y83Our7fSW+SEP8vRZklCElieYR85LHVB1QIEhoeHR7rc+Ifkw==}
     engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/errors@3.0.3':
-    resolution: {integrity: sha512-1l84xJlHNva6io62PcYfUamwWlc0eM95nHgCrKX0g0cLoC6D6QHYPCEbEVkR+C5UtP9JDgyQM8MFiv+Ei5tO9Q==}
-    engines: {node: '>=20.18.0'}
-    hasBin: true
     peerDependencies:
       typescript: '>=5.3.3'
 
@@ -1748,10 +1722,6 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  commander@14.0.0:
-    resolution: {integrity: sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==}
-    engines: {node: '>=20'}
 
   commander@14.0.1:
     resolution: {integrity: sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==}
@@ -3625,19 +3595,19 @@ snapshots:
       '@codama/errors': 1.4.1
       '@codama/node-types': 1.4.1
 
-  '@codama/renderers-core@1.2.5':
+  '@codama/renderers-core@1.3.0':
     dependencies:
       '@codama/errors': 1.4.1
       '@codama/nodes': 1.4.1
       '@codama/visitors-core': 1.4.1
 
-  '@codama/renderers-rust@1.2.7(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@codama/renderers-rust@1.2.8(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@codama/errors': 1.4.1
       '@codama/nodes': 1.4.1
-      '@codama/renderers-core': 1.2.5
+      '@codama/renderers-core': 1.3.0
       '@codama/visitors-core': 1.4.1
-      '@solana/codecs-strings': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       nunjucks: 3.2.4
     transitivePeerDependencies:
       - chokidar
@@ -4303,11 +4273,6 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@solana/codecs-core@3.0.3(typescript@5.9.3)':
-    dependencies:
-      '@solana/errors': 3.0.3(typescript@5.9.3)
-      typescript: 5.9.3
-
   '@solana/codecs-core@5.0.0(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 5.0.0(typescript@5.9.3)
@@ -4320,24 +4285,10 @@ snapshots:
       '@solana/errors': 5.0.0(typescript@5.9.3)
       typescript: 5.9.3
 
-  '@solana/codecs-numbers@3.0.3(typescript@5.9.3)':
-    dependencies:
-      '@solana/codecs-core': 3.0.3(typescript@5.9.3)
-      '@solana/errors': 3.0.3(typescript@5.9.3)
-      typescript: 5.9.3
-
   '@solana/codecs-numbers@5.0.0(typescript@5.9.3)':
     dependencies:
       '@solana/codecs-core': 5.0.0(typescript@5.9.3)
       '@solana/errors': 5.0.0(typescript@5.9.3)
-      typescript: 5.9.3
-
-  '@solana/codecs-strings@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
-    dependencies:
-      '@solana/codecs-core': 3.0.3(typescript@5.9.3)
-      '@solana/codecs-numbers': 3.0.3(typescript@5.9.3)
-      '@solana/errors': 3.0.3(typescript@5.9.3)
-      fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.9.3
 
   '@solana/codecs-strings@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
@@ -4358,12 +4309,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
-
-  '@solana/errors@3.0.3(typescript@5.9.3)':
-    dependencies:
-      chalk: 5.6.2
-      commander: 14.0.0
-      typescript: 5.9.3
 
   '@solana/errors@5.0.0(typescript@5.9.3)':
     dependencies:
@@ -4522,8 +4467,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.43.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.43.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.43.0
+      '@typescript-eslint/tsconfig-utils': 8.48.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.48.0
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -4999,8 +4944,6 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
-
-  commander@14.0.0: {}
 
   commander@14.0.1: {}
 

--- a/src/getRenderMapVisitor.ts
+++ b/src/getRenderMapVisitor.ts
@@ -759,10 +759,8 @@ export function getRenderMapVisitor(options: GetRenderMapOptions) {
 
                         definedTypes.push(...matrixProtoTypes);
 
-                        renderMap = addToRenderMap(
-                            renderMap,
-                            `proto/${protoProjectName}.proto`,
-                            render('proto.njk', {
+                        renderMap = addToRenderMap(renderMap, `proto/${protoProjectName}.proto`, {
+                            content: render('proto.njk', {
                                 accounts: protoAccounts,
                                 definedTypes,
                                 instructions: protoIxs,
@@ -772,7 +770,7 @@ export function getRenderMapVisitor(options: GetRenderMapOptions) {
                                 protoProjectName,
                                 types: protoTypes,
                             }),
-                        );
+                        });
 
                         if (protoTypesHelpers.length > 0 || protoTypesHelpersEnums.length > 0) {
                             hasProtoHelpers = true;
@@ -783,15 +781,13 @@ export function getRenderMapVisitor(options: GetRenderMapOptions) {
                                 });
                             };
 
-                            renderMap = addToRenderMap(
-                                renderMap,
-                                `src/generated_parser/proto_helpers.rs`,
-                                render('protoHelpersPage.njk', {
+                            renderMap = addToRenderMap(renderMap, `src/generated_parser/proto_helpers.rs`, {
+                                content: render('protoHelpersPage.njk', {
                                     normalizeAcronyms,
                                     protoTypesHelpers,
                                     protoTypesHelpersEnums,
                                 }),
-                            );
+                            });
                         }
                     }
 
@@ -815,51 +811,41 @@ export function getRenderMapVisitor(options: GetRenderMapOptions) {
 
                     // only two files are generated as part of account and instruction parser
                     if (accCtx.accounts.length > 0) {
-                        renderMap = addToRenderMap(
-                            renderMap,
-                            `src/generated_parser/accounts_parser.rs`,
-                            render('accountsParserPage.njk', accCtx),
-                        );
+                        renderMap = addToRenderMap(renderMap, `src/generated_parser/accounts_parser.rs`, {
+                            content: render('accountsParserPage.njk', accCtx),
+                        });
                     }
 
                     if (ixCtx.instructions.length > 0) {
-                        renderMap = addToRenderMap(
-                            renderMap,
-                            `src/generated_parser/instructions_parser.rs`,
-                            render('instructionsParserPage.njk', ixCtx),
-                        );
+                        renderMap = addToRenderMap(renderMap, `src/generated_parser/instructions_parser.rs`, {
+                            content: render('instructionsParserPage.njk', ixCtx),
+                        });
                     }
 
                     return pipe(
                         renderMap,
                         r =>
-                            addToRenderMap(
-                                r,
-                                `src/generated_parser/mod.rs`,
-                                render('rootMod.njk', {
+                            addToRenderMap(r, `src/generated_parser/mod.rs`, {
+                                content: render('rootMod.njk', {
                                     hasAccounts: accCtx.accounts.length > 0,
                                     hasProtoHelpers,
                                 }),
-                            ),
+                            }),
                         r =>
-                            addToRenderMap(
-                                r,
-                                'src/lib.rs',
-                                render('libPage.njk', {
+                            addToRenderMap(r, 'src/lib.rs', {
+                                content: render('libPage.njk', {
                                     programId: node.program.name,
                                     protoProjectName,
                                 }),
-                            ),
-                        r => addToRenderMap(r, 'build.rs', render('buildPage.njk', { protoProjectName })),
+                            }),
+                        r => addToRenderMap(r, 'build.rs', { content: render('buildPage.njk', { protoProjectName }) }),
                         r =>
-                            addToRenderMap(
-                                r,
-                                'Cargo.toml',
-                                render('CargoPage.njk', {
+                            addToRenderMap(r, 'Cargo.toml', {
+                                content: render('CargoPage.njk', {
                                     projectCrateDescription: options.projectCrateDescription,
                                     projectName,
                                 }),
-                            ),
+                            }),
                     );
                 },
             }),

--- a/test/accountsParserPage.test.ts
+++ b/test/accountsParserPage.test.ts
@@ -39,7 +39,7 @@ test('it renders accounts parsers', () => {
 
     // Then we expect the following identifier and reference to the byte array
     // as a parameters to be rendered.
-    codeContains(getFromRenderMap(renderMap, 'src/generated_parser/accounts_parser.rs'), [
+    codeContains(getFromRenderMap(renderMap, 'src/generated_parser/accounts_parser.rs').content, [
         'pub enum TestProgramState',
         'Mint(Mint)',
         'Account(Account)',

--- a/test/instructionsParserPage.test.ts
+++ b/test/instructionsParserPage.test.ts
@@ -150,8 +150,8 @@ test('it renders instructions parsers', () => {
     );
 
     // // Then we expect the following pub struct.
-    // codeContains(getFromRenderMap(renderMap, 'instructions/mint_tokens.rs'), [`pub struct MintTokensInstructionData`, `pub fn new(`]);
-    codeContains(getFromRenderMap(renderMap, 'src/generated_parser/instructions_parser.rs'), [
+    // codeContains(getFromRenderMap(renderMap, 'instructions/mint_tokens.rs').content, [`pub struct MintTokensInstructionData`, `pub fn new(`]);
+    codeContains(getFromRenderMap(renderMap, 'src/generated_parser/instructions_parser.rs').content, [
         'pub enum TestProgramIx',
         'CreateAccount(CreateAccountIxAccounts, CreateAccountIxData)',
         'Assign(AssignIxAccounts, AssignIxData)',


### PR DESCRIPTION
This PR bumps the `renderers-core` package and updates the use of `RenderMaps` to its latest definition (See https://github.com/codama-idl/codama/pull/927).