### PR TITLE
Prepare the release workflow for the branch-per-major model

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: Main
 
 on:
   push:
-    branches: [main]
+    branches: [main, '[0-9]+.x']
   pull_request:
-    branches: [main]
+    branches: [main, '[0-9]+.x']
 
 concurrency:
   group: main-${{ github.workflow }}-${{ github.ref }}
@@ -17,6 +17,7 @@ env:
   # Among other things, opts out of Turborepo telemetry. See https://consoledonottrack.com/.
   DO_NOT_TRACK: '1'
   NODE_VERSION: 24
+  RELEASE_VERSION: 1.x
   SOLANA_VERSION: 2.1.9
 
 jobs:
@@ -80,7 +81,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push'
     needs: [lint, tests]
     permissions:
       contents: write
@@ -118,8 +119,8 @@ jobs:
         uses: changesets/action@v2.1.1
         with:
           github-token: ${{ steps.app-token.outputs.token }}
-          commit-message: 'Publish package'
-          pr-title: 'Publish package'
+          commit-message: '[${{ env.RELEASE_VERSION }}] Publish package'
+          pr-title: '[${{ env.RELEASE_VERSION }}] Publish package'
           publish-script: pnpm publish-package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing
+
+Thanks for your interest in contributing to `@codama/renderers-vixen-parser`.
+
+## Getting set up
+
+You'll need Node.js and pnpm (see `engines` and `packageManager` in
+`package.json`). Then:
+
+```sh
+pnpm install
+pnpm build
+pnpm test
+pnpm lint
+```
+
+## Declaring release intent
+
+Any PR that ships a change to npm needs a changeset:
+
+```sh
+pnpm changeset
+```
+
+Pick the bump level (`patch` / `minor` / `major`), write a short user-facing
+summary, and commit the resulting `.changeset/*.md` alongside your code.
+
+## Releasing
+
+Patch and minor releases are automated: merging a PR with a changeset into
+`main` makes the release workflow open (or update) a release PR, and merging
+that release PR publishes the package to npm.
+
+Major releases follow the ecosystem-wide process described in the spec
+repository's [RELEASING.md](https://github.com/codama-idl/spec/blob/HEAD/RELEASING.md)
+(branch model, npm dist-tag conventions, release candidates, the bake window,
+and the cross-repo release train).


### PR DESCRIPTION
This PR prepares the repository for the branch-per-major release model defined in the ecosystem-wide [RELEASING.md](https://github.com/codama-idl/spec/blob/1.x/RELEASING.md): workflow triggers accept `main` and numeric `N.x` maintenance branches, the release job is branch-agnostic, and release commit/PR titles are prefixed with a new `RELEASE_VERSION` env. It also adds a `CONTRIBUTING.md` documenting the day-to-day flow and linking the release process.