### PR TITLE
Adopt the release-tools automation

### DIFF
--- a/.github/workflows/cut.yml
+++ b/.github/workflows/cut.yml
@@ -1,0 +1,25 @@
+name: Cut
+
+on:
+  workflow_dispatch:
+    inputs:
+      tracking-issue:
+        description: 'Open a transition tracking issue'
+        type: boolean
+        default: false
+      announce:
+        description: 'Open the announcement thread in the ecosystem hub Discussions'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  cut:
+    uses: codama-idl/release-tools/.github/workflows/cut.yml@v1
+    with:
+      tracking-issue: ${{ inputs.tracking-issue }}
+      announce: ${{ inputs.announce }}
+    secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,6 +119,7 @@ jobs:
         uses: changesets/action@v2.1.1
         with:
           github-token: ${{ steps.app-token.outputs.token }}
+          version-script: pnpm release:version
           commit-message: '[${{ env.RELEASE_VERSION }}] Publish package'
           pr-title: '[${{ env.RELEASE_VERSION }}] Publish package'
           publish-script: pnpm publish-package

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,11 @@
+name: Promote
+
+on: workflow_dispatch
+
+permissions:
+  contents: read
+
+jobs:
+  promote:
+    uses: codama-idl/release-tools/.github/workflows/promote.yml@v1
+    secrets: inherit

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "lint": "eslint . && prettier --check .",
         "lint:fix": "eslint --fix . && prettier --write .",
         "publish-package": "pnpm build && changeset publish",
+        "release:version": "changeset version && release-tools postversion",
         "test": "vitest run",
         "test:e2e": "./e2e/test.sh"
     },
@@ -41,15 +42,16 @@
         "@codama/errors": "^1.10.0",
         "@codama/nodes": "^1.10.0",
         "@codama/renderers-core": "^1.3.11",
-        "@codama/visitors-core": "^1.10.0",
         "@codama/renderers-rust": "^3.1.1",
+        "@codama/visitors-core": "^1.10.0",
         "@solana/codecs-strings": "^7.0.0",
         "nunjucks": "^3.2.4"
     },
     "devDependencies": {
-        "@codama/nodes-from-anchor": "1.5.5",
         "@changesets/changelog-github": "^1.0.0",
         "@changesets/cli": "^3.0.0",
+        "@codama/nodes-from-anchor": "1.5.5",
+        "@codama/release-tools": "github:codama-idl/release-tools#v1.0.0",
         "@solana/eslint-config-solana": "^5.0.0",
         "@solana/prettier-config-solana": "0.0.7",
         "@types/node": "^25",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@codama/nodes-from-anchor':
         specifier: 1.5.5
         version: 1.5.5(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@codama/release-tools':
+        specifier: github:codama-idl/release-tools#v1.0.0
+        version: https://codeload.github.com/codama-idl/release-tools/tar.gz/60c0f05d093d7c307ba80c20cd78e50e9dd1eb3e
       '@solana/eslint-config-solana':
         specifier: ^5.0.0
         version: 5.0.0(@eslint/js@9.39.1)(@types/eslint__js@8.42.3)(eslint-plugin-jest@29.0.1(@typescript-eslint/eslint-plugin@8.43.0(@typescript-eslint/parser@8.43.0(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1)(jest@30.1.3(@types/node@25.9.5))(typescript@5.9.3))(eslint-plugin-react-hooks@5.2.0(eslint@9.39.1))(eslint-plugin-simple-import-sort@12.1.1(eslint@9.39.1))(eslint-plugin-sort-keys-fix@1.1.2)(eslint-plugin-typescript-sort-keys@3.3.0(@typescript-eslint/parser@8.43.0(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1)(globals@14.0.0)(jest@30.1.3(@types/node@25.9.5))(typescript-eslint@8.43.0(eslint@9.39.1)(typescript@5.9.3))(typescript@5.9.3)
@@ -335,6 +338,12 @@ packages:
 
   '@codama/nodes@1.10.2':
     resolution: {integrity: sha512-wR2LKg6/GQ+ctgOiH9XPVb7ktq+gu7X/WEiCk45d4L1+P/JJh2kJeS/sMbktrgJNimcoO2G1Ms3+eUDjrwfo5g==}
+
+  '@codama/release-tools@https://codeload.github.com/codama-idl/release-tools/tar.gz/60c0f05d093d7c307ba80c20cd78e50e9dd1eb3e':
+    resolution: {tarball: https://codeload.github.com/codama-idl/release-tools/tar.gz/60c0f05d093d7c307ba80c20cd78e50e9dd1eb3e}
+    version: 1.0.0
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@codama/renderers-core@1.4.0':
     resolution: {integrity: sha512-JkqKWaN5nKampHgJ3jWh7u6kNPrwp7DB/lpkyS1hpL6NiC45tZGie6foaq8TnSTpaVPtVsL8Q46AP1MZpongpg==}
@@ -3629,6 +3638,8 @@ snapshots:
       '@codama/errors': 1.10.2
       '@codama/node-types': 1.10.2
 
+  '@codama/release-tools@https://codeload.github.com/codama-idl/release-tools/tar.gz/60c0f05d093d7c307ba80c20cd78e50e9dd1eb3e': {}
+
   '@codama/renderers-core@1.4.0':
     dependencies:
       '@codama/errors': 1.10.2
@@ -4532,8 +4543,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.43.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.43.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.43.0
+      '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.67.0
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:


### PR DESCRIPTION
This PR adopts [codama-idl/release-tools](https://github.com/codama-idl/release-tools) `v1.0.0` per [RELEASING.md](https://github.com/codama-idl/spec/blob/HEAD/RELEASING.md): the `postversion` guard chains after `changeset version` (blocking release PRs that cross a major illegally), and the `cut`/`promote` dispatch wrappers call the reusable workflows at `@v1`.